### PR TITLE
Replaced manually wrapped Core::DebugPrintFs

### DIFF
--- a/source/ht_gameobject.cpp
+++ b/source/ht_gameobject.cpp
@@ -13,10 +13,7 @@
 **/
 
 #include <ht_gameobject.h>
-
-#ifdef _DEBUG
-    #include <ht_debug.h>
-#endif
+#include <ht_debug.h>
 
 #include <algorithm>
 

--- a/source/ht_meshrenderer_component.cpp
+++ b/source/ht_meshrenderer_component.cpp
@@ -14,10 +14,7 @@
 
 #include <ht_meshrenderer_component.h>
 #include <ht_renderer_singleton.h>
-
-#ifdef _DEBUG
 #include <ht_debug.h>
-#endif
 
 namespace Hatchit {
 

--- a/source/ht_scene.cpp
+++ b/source/ht_scene.cpp
@@ -14,9 +14,7 @@
 
 #include <ht_scene.h>
 #include <ht_jsonhelper.h>
-#ifdef _DEBUG
-    #include <ht_debug.h>
-#endif
+#include <ht_debug.h>
 
 namespace Hatchit {
 

--- a/source/ht_scenemanager.cpp
+++ b/source/ht_scenemanager.cpp
@@ -14,10 +14,7 @@
 
 #include <ht_scenemanager.h>
 #include <ht_path_singleton.h>
-
-#ifdef _DEBUG
-    #include <ht_debug.h>
-#endif
+#include <ht_debug.h>
 #include <ht_os.h>
 
 namespace Hatchit {

--- a/source/ht_test_component.cpp
+++ b/source/ht_test_component.cpp
@@ -13,10 +13,7 @@
 **/
 
 #include <ht_test_component.h>
-
-#ifdef _DEBUG
-    #include <ht_debug.h>
-#endif
+#include <ht_debug.h>
 
 namespace Hatchit {
 

--- a/source/ht_window_singleton.cpp
+++ b/source/ht_window_singleton.cpp
@@ -52,9 +52,7 @@ namespace Hatchit {
 #endif
             if (!_instance.m_window->VInitialize())
             {
-#ifdef _DEBUG
-                Core::DebugPrintF("Failed to initialize Window. Exiting. \n");
-#endif
+                HT_DEBUG_PRINTF("Failed to initialize Window. Exiting. \n");
                 return false;
             }
 

--- a/source/sdl/ht_sdlwindow.cpp
+++ b/source/sdl/ht_sdlwindow.cpp
@@ -40,9 +40,7 @@ namespace Hatchit {
         bool SDLWindow::VInitialize()
         {
             if (SDL_Init(SDL_INIT_TIMER) != 0) {
-#ifdef _DEBUG
-                Core::DebugPrintF("SDL Failed to Initialize. Exiting\n");
-#endif
+                HT_DEBUG_PRINTF("SDL Failed to Initialize. Exiting\n");
                 return false;
             }
 
@@ -54,9 +52,7 @@ namespace Hatchit {
                 SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
             if (!m_handle)
             {
-#ifdef _DEBUG
-                Core::DebugPrintF("Failed to create SDL_Window handle. Exiting.\n");
-#endif 
+                HT_DEBUG_PRINTF("Failed to create SDL_Window handle. Exiting.\n");
                 SDL_Quit();
                 return false;
             }
@@ -83,9 +79,7 @@ namespace Hatchit {
                 m_glcontext = SDL_GL_CreateContext(m_handle);
                 if (!m_glcontext)
                 {
-#ifdef _DEBUG
-                    Core::DebugPrintF("Failed to create SDL_GL_Context handle. Exiting.\n");
-#endif
+                    HT_DEBUG_PRINTF("Failed to create SDL_GL_Context handle. Exiting.\n");
                     SDL_Quit();
                     return false;
                 }

--- a/source/xcb/ht_xcbwindow.cpp
+++ b/source/xcb/ht_xcbwindow.cpp
@@ -48,9 +48,7 @@ namespace Hatchit{
             m_connection = xcb_connect(nullptr, &src);
             if(m_connection == nullptr)
             {
-#ifdef _DEBUG
-                Core::DebugPrintF("Failed to connect XCB to X11 Server. Exiting.\n");
-#endif
+                HT_DEBUG_PRINTF("Failed to connect XCB to X11 Server. Exiting.\n");
                 return false;
             }
 


### PR DESCRIPTION
Replaced all manually #ifdef'd Core::DebugPrintF statements with
HT_DEBUG_PRINTF. Removed #ifdef around #include <ht_debug.h> that was
causing compiler errors in Release.
