### PR TITLE
Fix inconsistency with GameObject::AddComponent.

### DIFF
--- a/include/ht_gameobject.h
+++ b/include/ht_gameobject.h
@@ -356,7 +356,8 @@ namespace Hatchit {
 
             component->VOnInit();
 
-            component->Enable();
+            if(m_enabled)
+                component->Enable();
 
             return true;
         }


### PR DESCRIPTION
GameObject::AddComponent<T> and GameObject<T, Args...> now have the same
behavior.
