### PR TITLE
Fix for thirddegree/hatchitgame#29.

### DIFF
--- a/include/ht_camera_component.h
+++ b/include/ht_camera_component.h
@@ -50,6 +50,7 @@ namespace Hatchit {
             */
             Component* VClone(void) const override;
 
+            virtual Core::Guid VGetComponentId(void) const override;
         protected:
 
             /**

--- a/include/ht_component.h
+++ b/include/ht_component.h
@@ -105,6 +105,8 @@ namespace Hatchit {
             */
             virtual Component* VClone(void) const = 0;
 
+            virtual Core::Guid VGetComponentId(void) const = 0;
+
             /**
             * \brief Setter that sets which GameObject this Component is attached to.
             * \param owner  The GameObject to which this Component is attached.
@@ -132,7 +134,7 @@ namespace Hatchit {
         template <typename T>
         Core::Guid Component::GetComponentId(void)
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
             static Core::Guid id = Core::Guid(); /**< This value is set once when the template is instantiated. */
             return id;
         }

--- a/include/ht_gameobject.h
+++ b/include/ht_gameobject.h
@@ -370,10 +370,31 @@ namespace Hatchit {
             return true;
         }
 
+        template <>
+        inline bool GameObject::AddComponent<Component>(Component *component)
+        {
+            Core::Guid component_id = component->VGetComponentId();
+            std::unordered_map<Core::Guid, std::vector<Component*>::size_type>::const_iterator iter = m_componentMap.find(component_id);
+            if (iter != m_componentMap.cend())
+                return false;
+
+            m_componentMap.insert(std::make_pair(component_id, m_components.size()));
+            m_components.push_back(component);
+
+            component->SetOwner(this);
+
+            component->VOnInit();
+
+            if (m_enabled)
+                component->SetEnabled(true);
+
+            return true;
+        }
+
         template <typename T, typename... Args>
         bool GameObject::AddComponent(Args&&... args)
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
 
             Core::Guid component_id = Game::Component:: template GetComponentId<T>();
             std::unordered_map<Core::Guid, std::vector<Component*>::size_type>::const_iterator iter = m_componentMap.find(component_id);
@@ -397,7 +418,7 @@ namespace Hatchit {
         template <typename T>
         bool GameObject::RemoveComponent(void)
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
 
             Core::Guid component_id = Game::Component:: template GetComponentId<T>();
             std::unordered_map<Core::Guid, std::vector<Component*>::size_type>::const_iterator iter = m_componentMap.find(component_id);
@@ -420,7 +441,7 @@ namespace Hatchit {
         template <typename T>
         bool GameObject::HasComponent(void) const
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
             Core::Guid component_id = Component:: template GetComponentId<T>();
             return (m_componentMap.find(component_id) != m_componentMap.cend());
         }
@@ -428,14 +449,14 @@ namespace Hatchit {
         template <typename T1, typename T2, typename... Args>
         bool GameObject::HasComponent(void) const
         {
-            static_assert(std::is_base_of<Component, T1>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T1>::value && !std::is_same<Component, T1>::value, "Must be a sub-class of Hatchit::Game::Component!");
             return HasComponent<T1>() && HasComponent<T2, Args...>();
         }
 
         template <typename T>
         T* GameObject::GetComponent(void)
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
 
             Core::Guid component_id = Component::GetComponentId<T>();
             std::unordered_map<Core::Guid, std::vector<Component*>::size_type>::const_iterator iter = m_componentMap.find(component_id);
@@ -455,7 +476,7 @@ namespace Hatchit {
         template <typename T>
         bool GameObject::EnableComponent(void)
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
 
             if (!HasComponent<T>())
                 return false;
@@ -474,7 +495,7 @@ namespace Hatchit {
         template <typename T>
         bool GameObject::DisableComponent(void)
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
 
             if (!HasComponent<T>())
                 return false;
@@ -508,10 +529,26 @@ namespace Hatchit {
             return true;
         }
 
+        template<>
+        inline bool GameObject::AddUninitializedComponent<Component>(Component* component)
+        {
+            Core::Guid component_id = component->VGetComponentId();
+            std::unordered_map<Core::Guid, std::vector<Component*>::size_type>::const_iterator iter = m_componentMap.find(component_id);
+            if (iter != m_componentMap.cend())
+                return false;
+
+            m_componentMap.insert(std::make_pair(component_id, m_components.size()));
+            m_components.push_back(component);
+
+            component->SetOwner(this);
+
+            return true;
+        }
+
         template<typename T, typename ...Args>
         inline bool GameObject::AddUninitializedComponent(Args && ...args)
         {
-            static_assert(std::is_base_of<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
+            static_assert(std::is_base_of<Component, T>::value && !std::is_same<Component, T>::value, "Must be a sub-class of Hatchit::Game::Component!");
 
             Core::Guid component_id = Game::Component:: template GetComponentId<T>();
             std::unordered_map<Core::Guid, std::vector<Component*>::size_type>::const_iterator iter = m_componentMap.find(component_id);

--- a/include/ht_light_component.h
+++ b/include/ht_light_component.h
@@ -46,6 +46,7 @@ namespace Hatchit {
 
             Component* VClone() const override;
 
+            virtual Core::Guid VGetComponentId(void) const override;
         protected:
 
             void VOnEnabled() override;

--- a/include/ht_meshrenderer_component.h
+++ b/include/ht_meshrenderer_component.h
@@ -48,6 +48,7 @@ namespace Hatchit {
             */
             Component* VClone() const override;
 
+            virtual Core::Guid VGetComponentId(void) const override;
         protected:
 
             /**

--- a/include/ht_test_component.h
+++ b/include/ht_test_component.h
@@ -30,6 +30,7 @@ namespace Hatchit {
             void VOnInit() override;
             void VOnUpdate() override;
             Component* VClone(void) const override;
+            virtual Core::Guid VGetComponentId(void) const override;
         protected:
             void VOnEnabled() override;
             void VOnDisabled() override;

--- a/include/ht_tween_component.h
+++ b/include/ht_tween_component.h
@@ -220,6 +220,7 @@ namespace Hatchit {
             */
             Component* VClone(void) const override;
 
+            virtual Core::Guid VGetComponentId(void) const override;
         protected:
             static std::vector<TweenFunction> s_tweenFunctions;
 

--- a/include/ht_tween_position.h
+++ b/include/ht_tween_position.h
@@ -72,6 +72,8 @@ namespace Hatchit {
             * \brief Creates a copy of this Component.
             */
             Component* VClone(void) const override;
+
+            virtual Core::Guid VGetComponentId(void) const override;
         };
 
     }

--- a/include/ht_tween_rotation.h
+++ b/include/ht_tween_rotation.h
@@ -72,6 +72,8 @@ namespace Hatchit {
             * \brief Creates a copy of this Component.
             */
             Component* VClone(void) const override;
+
+            virtual Core::Guid VGetComponentId(void) const override;
         };
 
     }

--- a/include/ht_tween_scale.h
+++ b/include/ht_tween_scale.h
@@ -73,6 +73,8 @@ namespace Hatchit {
             * \brief Creates a copy of this Component.
             */
             Component* VClone(void) const override;
+
+            virtual Core::Guid VGetComponentId(void) const override;
         };
 
     }

--- a/source/ht_camera_component.cpp
+++ b/source/ht_camera_component.cpp
@@ -70,6 +70,15 @@ namespace Hatchit {
             return new Camera(*this);
         }
 
+        /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid Camera::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<Camera>();
+        }
     }
 
 }

--- a/source/ht_light_component.cpp
+++ b/source/ht_light_component.cpp
@@ -127,6 +127,16 @@ namespace Hatchit {
         }
 
         /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid LightComponent::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<LightComponent>();
+        }
+
+        /**
         * \brief Called when the Component is enabled.
         * This happens when a scene has finished loading, or immediately after creation if the scene is already loaded.
         */

--- a/source/ht_meshrenderer_component.cpp
+++ b/source/ht_meshrenderer_component.cpp
@@ -120,6 +120,16 @@ namespace Hatchit {
             return new MeshRenderer(*this);
         }
 
+        /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid MeshRenderer::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<MeshRenderer>();
+        }
+
         void MeshRenderer::VOnEnabled()
         {
             HT_DEBUG_PRINTF("Enabled MeshRenderer Component.\n");

--- a/source/ht_test_component.cpp
+++ b/source/ht_test_component.cpp
@@ -42,6 +42,16 @@ namespace Hatchit {
             return new TestComponent(*this);
         }
 
+        /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid TestComponent::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<TestComponent>();
+        }
+
         void TestComponent::VOnEnabled()
         {
             HT_DEBUG_PRINTF("Enabled Test Component.\n");

--- a/source/ht_tween_component.cpp
+++ b/source/ht_tween_component.cpp
@@ -376,6 +376,15 @@ namespace Hatchit {
             return new TweenComponent(*this);
         }
 
+        /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid TweenComponent::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<TweenComponent>();
+        }
     }
 
 }

--- a/source/ht_tween_position.cpp
+++ b/source/ht_tween_position.cpp
@@ -105,6 +105,15 @@ namespace Hatchit {
             return new TweenPosition(*this);
         }
 
+        /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid TweenPosition::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<TweenPosition>();
+        }
     }
 
 }

--- a/source/ht_tween_rotation.cpp
+++ b/source/ht_tween_rotation.cpp
@@ -105,6 +105,15 @@ namespace Hatchit {
             return new TweenRotation(*this);
         }
 
+        /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid TweenRotation::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<TweenRotation>();
+        }
     }
 
 }

--- a/source/ht_tween_scale.cpp
+++ b/source/ht_tween_scale.cpp
@@ -105,6 +105,15 @@ namespace Hatchit {
             return new TweenScale(*this);
         }
 
+        /**
+        * \brief Retrieves the id associated with this class of Component.
+        * \return The Core::Guid associated with this Component type.
+        * \sa Component(), GameObject()
+        */
+        Core::Guid TweenScale::VGetComponentId(void) const
+        {
+            return Component::GetComponentId<TweenScale>();
+        }
     }
 
 }


### PR DESCRIPTION
The issue that caused this was that Hatchit::Game::Component was a viable
template instantiation for Hatchit::Game::Component::GetComponentId<T>.
This caused problems in the JSON parsing code in Hatchit::Game::Scene
which deals primarily with pointers to Hatchit::Game::Components, all
Hatchit::Game::Components were being added with the same
Hatchit::Core::Guid because of this. Added a virtual VGetComponentId
function to the Hatchit::Game::Component class so that we can determine
the Core::Guid of an unknown Component. Added template specializations for
Hatchit::Game::GameObject::AddComponent and
Hatchit::Game::GameObject::AddUnitializedComponent, which accept a pointer
to a Hatchit::Game::Component and use VGetComponentId to appropriately
store the Hatchit::Game::Component. Updated all other templated
Hatchit::Game::GameObject functions to no longer accept
Hatchit::Game::Component as a valid template instantiation.
